### PR TITLE
fixed the error in utils.c by including stdio.h library

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include <stdio.h>
 
 uint32_t add_with_carry(uint32_t x, uint32_t y, bool carry, struct add_with_carry_result *target)
 {


### PR DESCRIPTION
Got the following error while running make on WSL2 Ubuntu

` [ C ] src/utils.c
src/utils.c:34:5: error: implicitly declaring library function 'printf' with type
      'int (const char *, ...)' [-Werror,-Wimplicit-function-declaration]
    printf("error: lsr_c is not implemented \n");
    ^
src/utils.c:34:5: note: include the header <stdio.h> or explicitly provide a declaration for
      'printf'
1 error generated.
Makefile:27: recipe for target 'build/./src/utils.o' failed
make: *** [build/./src/utils.o] Error 1`

It can be fixed just by including the stdio.h in the utils.c file or by explicitly declaring the printf function. I included the stdio.h library in utils.c and everything worked fine.