### PR TITLE
Fix (small) memory leak

### DIFF
--- a/src/pico_rom.c
+++ b/src/pico_rom.c
@@ -92,12 +92,13 @@ int init_rom(struct pico_cpu *cpu)
 bool init_boot_rom_vector(struct pico_bootrom_vector *target, struct pico_cpu *cpu)
 {
     size_t length_to_read = sizeof(struct pico_bootrom_vector);
-    uint8_t *raw_target = malloc(sizeof(struct pico_bootrom_vector));
+	uint8_t *raw_target = malloc(sizeof(struct pico_bootrom_vector));
 
     for (uint32_t i = 0; i < length_to_read; i++)
     {
         if (read_memory_byte(cpu, raw_target + i, i) != 0)
         {
+			free(raw_target);
             return 0;
         }
     }


### PR DESCRIPTION
What's happening:
* When the emulator cannot find the bootrom, the function `init_boot_rom_vector` returns when it forgot to deallocate the `raw_target` variable.

What I did:
* Added a `free` right before the function `init_boot_rom_vector` returns when no bootrom is found.

Though the memory leak is minimal (26 bytes), I thought to quickly patch this before anything happens.